### PR TITLE
Big Rewrite #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,26 @@ Spotify New Music Notifier
 
 Note: this project is still a work in progress
 
-This Python script will alert the user about new music from artists they follow by calling the Spotify API using Spotipy. It collects the information, compares it against previously indexed artists, and notifies the user about new music with an email if they would like. The new music is also added to a playlist on the user's account.
+This Python script adds new releases from artists users follow to a playlist on their account by calling the Spotify API using Spotipy. It collects followed artist's releases, determines which are new, and adds them to the correct playlists. If a user would like, emails can be sent to notify them of new music as well.
 
 ## How To Use
+
+This script is built to be run for multiple users whose API access tokens are stored as cache files.
+To run it for multiple users, or yourself:
 
 1. Follow all the artists on Spotify you want to be notified about.
 2. Create a new app on the Spotify Developers Dashboard and give it a Redirect URI (I use "http://localhost:8080/")
 	1. On the app's dashboard, you will find the Client ID and Secret to put in app_info.txt
 3. Replace the lines of app_info.txt with your information
-	1. Your Spotify username will be a string of numbers if you signed up with Facebook, otherwise, it will be the username you use to log in
-	2. The lines regarding email are optional (refer to step 8), if you would not like email notifications do not touch these
+	1. For email functionality, create a new throwaway email address and put your log-in details in the text file, be sure to enable third-party app access
 4. Install Spotipy
-5. Run the script with Python once, it will have you log in through a browser and the program will perform an initial index of all your followed artists to data.txt
-	1. The program will open a link in-browser, wait several seconds then copy the URL in the address bar and paste it into the program as input (this will generate a cache file for you)
-7. The script and all associated files will then need to be put in a service that runs it on an interval (every day, once a week, etc), such as a scheduler
-	1. I use pythonanywhere because it's easy to set up, just be sure to "pip install --user Spotipy" through the Bash console
-8. If you would like email notifications, create a new throwaway Gmail account for sending emails (enable third-party app access), fill in app_info.txt
-	1. The receiver address is likely to be your personal email address depending on where you want the emails about new music to be sent
+5. Create cache files for all the users you want with generate_cache.py and put them in the cache_files folder
+	1. This file creates a Spotipy cache file for the user currently signed into the default browser and pairs it with the username console input
+	2. After typing a username, the file will open a link in-browser, wait several seconds then copy the URL in the address bar and paste it into the program as input
+6. The notifier.py script assumes it will be run once a day after midnight
+	1. The script and all associated files can be put in a service that runs it every day, such as a scheduler
+	2. I use pythonanywhere because it's easy to set up, just be sure to "pip install --user Spotipy" through the Bash console
 
 ## How It Works
 
-The script will call out to the API for each artist indexed in a file called data.txt as JSON. If it is the first time being run it will generate this file for use the next time the script is run. If there are any differences between what is indexed and what is received from the API, that indicates that there is new music. The script will collect this music and add every song to a playlist called "New Music" on the user's account, if the playlist does not exist yet, it will be created and its id will be stored in app_info.txt. An email notification will also be sent to the user if it is set up.
+The script stores information about users from the cache_files folder in user_info.txt as json. It will add new users and update existing ones before calling the API for every artist followed by the userbase as a whole. It collects each artist's music and determines which is new by comparing the release date with today's date. If new music is found, it is added to the respective user's playlist. If no playlist exists for a user, the script creates one on their account. Any new music is logged as a new dated file in the logs folder. Finally, email notifications are sent out to users who got new music and have an email paired with their username.

--- a/app_info.txt
+++ b/app_info.txt
@@ -1,8 +1,5 @@
-(Spotify Username)
 (Spotify App Client ID)
 (Spotify App Secret)
 (Spotify App Redirect URI)
-(Sender Email Address *Optional)
-(Sender Email Address Password *Optional)
-(Receiver Email Address *Optional)
--DO NOT MODIFY BELOW THIS LINE-
+(Sender Email Address)
+(Sender Email Address Password)

--- a/generate_cache.py
+++ b/generate_cache.py
@@ -1,0 +1,13 @@
+import spotipy
+import spotipy.util as util
+
+if __name__ == '__main__':
+    with open("app_info.txt") as app_info:
+        username = input("Enter username: ")
+        client_id = app_info.readline()
+        client_secret = app_info.readline()
+        redirect_uri = app_info.readline()
+        scope = "playlist-modify-private playlist-modify-public user-follow-read ugc-image-upload"
+
+        token = util.prompt_for_user_token(username, scope, client_id, client_secret, redirect_uri)
+        sp = spotipy.Spotify(token)

--- a/notifier.py
+++ b/notifier.py
@@ -6,7 +6,7 @@ from email.mime.multipart import MIMEMultipart
 import base64
 import json
 import os
-import datetime
+from datetime import datetime, timedelta, date
 
 def read_app_info():
     """
@@ -15,250 +15,284 @@ def read_app_info():
     """
     # get info from app_info.txt
     file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "app_info.txt") # adds the path up to the file for running different working directory settings
-    app_info_fp = open(file_name)
+    with open(file_name) as app_info_fp:
     
-    username = app_info_fp.readline().strip()
-    client_id = app_info_fp.readline().strip()
-    client_secret = app_info_fp.readline().strip()
-    redirect_uri = app_info_fp.readline().strip()
-    sender_email = app_info_fp.readline().strip()
-    sender_password = app_info_fp.readline().strip()
-    receiver_email = app_info_fp.readline().strip()
-    placeholder = app_info_fp.readline().strip()
+        client_id = app_info_fp.readline().strip()
+        client_secret = app_info_fp.readline().strip()
+        redirect_uri = app_info_fp.readline().strip()
+        sender_email = app_info_fp.readline().strip()
+        sender_password = app_info_fp.readline().strip()
 
-    try:
-        playlist_id = app_info_fp.readline().strip()
-    except: # there is not an existing playlist_id in app_info
-        playlist_id = ""
-
-    app_info_fp.close()
-
-    return [username, client_id, client_secret, redirect_uri, sender_email, sender_password, receiver_email, placeholder, playlist_id]
+    return [client_id, client_secret, redirect_uri, sender_email, sender_password]
 
 def set_credentials(username, client_id, client_secret, redirect_uri):
     """
-        Sets the developer credentials for accessing the Spotify API and creates a Spotipy object for calling the API.
-        :param username: username from app_info.txt
+        Sets the developer credentials for accessing the Spotify API and creates a Spotipy object for calling it.
+        :param username: a Spotify username
         :param client_id: Spotify app client_id from app_info.txt
         :param client_secret: Spotify app client_secret from app_info.txt
         :param redirect_uri: Spotify app redirect_uri from app_info.txt
         :return: sp (a Spotipy object)
     """
     scope = "playlist-modify-private playlist-modify-public user-follow-read ugc-image-upload"
-    token = util.prompt_for_user_token(username, scope, client_id, client_secret, redirect_uri)
+
+    path = os.getcwd() + "\\cache_files\\.cache-" + username # look in cache_files folder for a previously generated cache file for the username
+    token = util.prompt_for_user_token(username, scope, client_id, client_secret, redirect_uri, path)
     sp = spotipy.Spotify(token)
     return sp
 
-def recent_release_date(id):
+def update_user_info(username, sp):
     """
-    Gets the given album_id release date from the API and checks if it was released within the last two days, if it is returns True, False otherwise.
+        Will create user_info.txt if it does not exist then fetches data from the api for each user placed in the cache_files folder.
+        If a user does not exist in user_info.txt for a cache file, a playlist will be made for the user and the function will request an email via the console.
+        If a user already exists in user_info.txt, their followed artists will be updated.
+        :param username: a Spotify username
+        :param sp: a Spotipy object
+        :return: user_info (the contents of user_info.txt, a dict of information about each user)
     """
-    date_parts = sp.album(id)["release_date"].split('-') # formatted: 'XXXX-XX-XX'
-    release_date = datetime.date(int(date_parts[0]), int(date_parts[1]), int(date_parts[2]))
-    if datetime.date.today() - datetime.timedelta(days=2) > release_date: # was not released in past 2 days
-        return False
-    return True
-
-def get_new_music(saved_data, api_data):
-    """
-        Compares saved_data and api_data, compiles a dict of artists with new music.
-        :param saved_data: a dict of indexed data from data.txt
-        :param api_data: a dict of up-to-date data from the API
-        :return: new_music (a dict of new music)
-    """
-    new_music = {} # a dict to represent artists with new music with titles of the new singles/albums, structured differently than other dicts like api_data
-
-    for artist in api_data.keys(): # artist is an artist_id in this case
-        if artist in saved_data.keys(): # artist has been previously indexed
-            # see if there is a discrepancy between the two regarding the saved albums/singles
-            if sorted(api_data[artist]["singles"].keys()) != sorted(saved_data[artist]["singles"].keys()) or \
-                sorted(api_data[artist]["albums"].keys()) != sorted(saved_data[artist]["albums"].keys()): # we use sorted here because sometimes the order of album ids from the api changes
-                
-                # get a list of albums that appear in the new data that do not appear in the indexed data
-                new_albums = list(set(api_data[artist]["albums"].keys()) - set(saved_data[artist]["albums"].keys())) # set difference
-                new_singles = list(set(api_data[artist]["singles"].keys()) - set(saved_data[artist]["singles"].keys())) # set difference
-
-                # remove albums that were not released in the last 2 days
-                for id in new_albums[:]: # for id in a copy of new_albums
-                    if not recent_release_date(id):
-                        new_albums.remove(id)
-
-                # remove singles that were not released in the last 2 days
-                for id in new_singles[:]: # for id in a copy of new_albums
-                   if not recent_release_date(id):
-                        new_singles.remove(id)
-
-                if new_albums + new_singles != []: # new music was found, add it to the new_music dict
-                    new_music[artist] = {}
-                    new_music[artist]["name"] = api_data[artist]["name"]
-                    new_music[artist]["albums"] = new_albums
-                    new_music[artist]["singles"] = new_singles
-
-    file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data.txt") # adds the path up to the file for running different working directory settings
-    with open(file_name, 'w') as out_file:
-        json.dump(api_data, out_file) # update indexed data with up-to-date data
-
-    return new_music
+    file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "user_info.txt")
+    try:
+        in_file = open(file_name) # will try to open file
+        user_info = json.load(in_file)
+    except: # file not created yet
+        user_info = {}
+        
+    if username not in user_info.keys():
+        user_info[username] = {}
+        user_info[username]["playlist_id"] = create_playlist(username, sp) # creates playlist on the account and returns the id
+        user_info[username]["email"] = input("Enter new user email: ") # get user email from console
+     
+    # update followed_artists for the user
+    user_info[username]["followed_artists"] = get_followed_artists(username, sp) # gets a dict of form artist_id:artist_name
     
-def get_latest(artist, album_type, sp):
-    """
-        Calls the API for information about the given artist's album_type. Creates a list
-        of the latest items of album_type up to a max of 5, skipping duplicates.
-        :param artist: the artist id to look up (string)
-        :param album_type: either "single" or "album"
-        :param sp: the Spotipy object
-        :return: music (a dict of 5 album_types where the key:value is album_id:album_name)
-    """
-    music = {}
-    results = sp.artist_albums(artist, album_type, country="US", limit=5) # calls API and gets a dict
-    for item in results["items"]:
-        music[item["id"]] = item["name"]
-    
-    return music
+    try: # will close the file if it was opened previously
+        in_file.close()
+    except:
+        pass
 
-def update_followed_artists(sp):
+    with open(file_name, 'w') as out_file: # write to user_info.txt, create file if it does not exist
+        json.dump(user_info, out_file)
+    
+    return user_info
+
+def create_playlist(username, sp):
     """
-        Calls the API for the current authorized user to get their followed artists and updates the saved_data json for any new artists.
-        The API can only be called with 50 artists at a time, so the function will loop until complete.
-        * Performs round_up(number_of_followed_users/50) calls for the first call
-        * Performs 2*number_of_followed_users for second calls (through get_latest)
-        :param sp: the Spotipy object
-        :return: the results from a call to get_new_music (a dict) or None (no previously indexed data)
+        Creates a playlist on the username's account and gives it the cover photo of "playlist_cover.jpg".
+        :param username: a Spotify username
+        :param sp: a Spotipy object
+        :return: the playlist id of the playlist just created (str)
     """
-    # fill out the api_data dictionary with information from the API
+    playlist = sp.user_playlist_create(username, "New Music", False, "New music from music notifier, checked daily and updated here.")
+        
+    # add a playlist cover
+    file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "playlist_cover.jpg")
+    with open(file_name, "rb") as img_file:
+        image_data = base64.b64encode(img_file.read())
+        sp.playlist_upload_cover_image(playlist["id"], image_data)
+    
+    return playlist["id"]
+
+def get_followed_artists(username, sp):
+    """
+        Calls the API for the user and gets a dictionary of information about the artists they follow, then turns it into a dict of artist_id:artist_name.
+        :param username: a Spotify username
+        :param sp: a Spotipy object
+        :return: followed_artists (a dict representing information about the artists the username follows)
+    """
     num_recieved_artists = 50
     after_id = None # after_id is the last artist ID retrieved from the previous request, starts as None
 
-    api_data = {} # will represent up-to-date information regarding followed artists and their latest single/albums
-    while num_recieved_artists == 50:
+    followed_artists = {} # will represent information about the user's followed artists
+    while num_recieved_artists == 50: # the last call to the API will get 50 or less artists
         artists_dict = sp.current_user_followed_artists(50, after_id) # call API to get a dictionary of 50 followed artists
-        after_id = artists_dict["artists"]["cursors"]["after"] # update after_id for use in next call if necessary
-        num_recieved_artists = len(artists_dict["artists"]["items"])
+        try: 
+            after_id = artists_dict["artists"]["cursors"]["after"] # update after_id for use in next call if necessary
+            num_recieved_artists = len(artists_dict["artists"]["items"])
 
-        for artist in artists_dict["artists"]["items"]:
-            api_data[artist["id"]] = {}
-            api_data[artist["id"]]["name"] = artist["name"]
-            # calls API through get_latest to get the artists singles and albums
-            api_data[artist["id"]]["singles"] = get_latest(artist["id"], "single", sp)
-            api_data[artist["id"]]["albums"] = get_latest(artist["id"], "album", sp)
+            for artist in artists_dict["artists"]["items"]: # populate followed_artists
+                followed_artists[artist["id"]] = artist["name"]
+        except: # edge case for if user is following a number of artists divisible by 50
+            break
 
-    # try to read the data from data.txt
-    file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data.txt") # adds the path up to the file for running different working directory settings
-    try:
-        with open(file_name) as json_file:
-            saved_data = json.load(json_file)
-    except: # file is empty, not formatted correctly, or does not exist
-        saved_data = {}
+    return followed_artists
 
-    if saved_data == {}: # likely a first time user so no indexed info yet
-        # write data (this path will not trigger a notification)
-        with open(file_name, 'w') as out_file:
-            json.dump(api_data, out_file)
-    else:
-        return get_new_music(saved_data, api_data) # compare data indexed to new data from api and collect new music
-
-def send_email(sender_email, sender_password, receiver_email, playlist_id):
+def remove_users(users, user_info):
     """
-        Sends an email to the provided address with a link to the user's playlist.
-        This email simply serves as a notification.
+        Removes users who have been previously saved in user_info.txt, but no longer appear in cache_files to prevent unnecessary API calls when getting new music.
+        :param users: usernames that appear in the cache_files folder (list)
+        :param user_info: the json curently stored in user_info.txt, guaranteed up-to-date (dict)
+    """
+    removed_user = False
+    for indexed_user in list(user_info.keys())[:]:
+        if indexed_user not in users:
+            user_info.pop(indexed_user, None)
+            removed_user = True
+
+    if removed_user: # a user was removed from user_info, update the user_info.txt text file
+        file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "user_info.txt")
+        with open(file_name, 'w') as out_file:
+            json.dump(user_info, out_file)
+
+def get_new_music(user_info):
+    """
+        Calls the API for every unique artist followed by the whole userbase.
+        Gets each artist's last 5 albums and singles, determines if they are new by comparing today's date and the release date.
+        If new music is found, the api data gets added to the new_music dict
+        Creates the log_information dict with usernames to be filled with data later
+        :param user_info: the json curently stored in user_info.txt, guaranteed up-to-date (dict)
+        :param return: new_music (a dict of new music from artists the userbase follows, formatted artist_id:album_dict)
+        :param return: log_information (a dict of information to later write into the logs folder, this funciton only fills it with usernames from user_info)
+    """
+    print("Calling API for new music")
+    log_information = {}
+    new_music = {}
+    
+    followed_artists = set()
+    for username in user_info.keys(): # fill followed_artists with ids of all followed artists for all users, ignore duplicaates
+        followed_artists.update(user_info[username]["followed_artists"].keys())
+        log_information[username] = []
+
+    for artist_id in followed_artists:
+        # call api for each artist and get their last 5 albums and singles
+        albums = sp.artist_albums(artist_id, "album", country="US", limit=5)
+        singles = sp.artist_albums(artist_id, "single", country="US", limit=5)
+        
+        # fill a list with all the music received for the artist
+        music = []
+        music.extend(albums["items"])
+        music.extend(singles["items"])
+        
+        for album in music:
+            # get the release date and turn it into a date type
+            date_parts = album["release_date"].split('-') # usually formatted: "XXXX-XX-XX"
+            try:
+                release_date = date(int(date_parts[0]), int(date_parts[1]), int(date_parts[2]))
+            except: 
+                # the format of the release_date is not always year-month-day
+                # the release_date_precision for albums can vary, for example, it may only include the year
+                # in this case we ignore the release, assuming all newer music has the necessary metadata
+                continue
+            
+            # this is what determines if an album is new or not
+            if release_date + timedelta(days = 1) >= date.today(): # was released today or yesterday
+                # if it was released yesterday, we need to make sure it was after the script ran (checks logs to do this)
+                file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs\\" + str(date.today() - timedelta(days = 1)) + ".txt")
+                try: # see if there was a log generated yesterday
+                    in_file = open(file_name) # will try to open file
+                    yesterday_log = json.load(in_file)
+
+                    #TODO this is inefficient, could be improved
+                    for user in yesterday_log.keys(): # loop over each user, see if the album id was added for any of them
+                        if album["id"] in yesterday_log[user]: # album has already been added to users who follow the artist
+                            raise Exception("Album already added")
+                    
+                    # the release has not been previously added. Add the artist if necessary, then the album
+                    if artist_id in new_music.keys():
+                        new_music[artist_id].append(album)
+                    else:
+                        new_music[artist_id] = [album]
+                except:
+                    # album was added yesterday, or no log could be found
+                    pass
+
+    return new_music, log_information
+
+def update_playlists(user_info, new_music, spotipy_objects, log_information):
+    """
+        Updates the playlists of users who follow artists who appear in the new_music dict.
+        Creates a text file in the logs folder with generate_logs() of users who had new music added to their playlists.
+        :param user_info: the json curently stored in user_info.txt, guaranteed up-to-date (dict)
+        :param new_music: a dict of new music from artists the userbase follows, formatted artist_id:album_dict
+        :param spotipy_objects: a list of Spotipy objects created for each cache file in order to have proper permissions for editing each user's playlist
+        :param log_information: a dict of usernames from user_info formatted username:[]
+        :return: users_to_email (a set of users who had their playlists updated)
+    """
+    users_to_email = set()
+    for artist_id in new_music.keys():
+        users_to_update = [] # a list of users whose playlists we will update with the specific new item
+        for username in user_info.keys():
+            if artist_id in user_info[username]["followed_artists"].keys(): # the user follows one of the artists who has new music
+                users_to_email.add(username)
+                users_to_update.append(username)
+        
+        song_ids = []
+        for album in new_music[artist_id]:
+            for song in sp.album(album["id"])["tracks"]["items"]: # call API to get all the song ids for the given album id
+                song_ids.append(song["id"])
+        for username in users_to_update: # add songs to the users playlist
+            spotipy_objects[username].user_playlist_add_tracks(username, user_info[username]["playlist_id"], song_ids) # add tracks
+            log_information[username].append(album["id"]) # create logs
+
+    generate_logs(log_information)
+
+    return users_to_email
+
+def generate_logs(log_information):
+    """Write log_information as a json to a new dated text file in the logs folder"""
+    file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs\\" + str(date.today()) + ".txt")
+    with open(file_name, 'w') as out_file: # write to user_info
+        json.dump(log_information, out_file)
+
+def send_email(sender_email, sender_password, users_to_email, user_info):
+    """
+        Sends a notification email to every user in users_to_email if they have a paired email in user_info.
+        Uses the sender_email and sender_password from the app_info.txt file.
         :param sender_email: the address the email will be sent from
         :param sender_password: the password for the sender_email
-        :param receiver_email: the address that will receive the email sent from sender_email
-        :param playlist_id: id of playlist to link in email
+        :param users_to_email: a list of users who had their playlists updated with new music
+        :param user_info: the json curently stored in user_info.txt, guaranteed up-to-date (dict)
     """
-    message = MIMEMultipart("alternative")
-    message["Subject"] = "New music on Spotify"
-    message["From"] = sender_email
-    message["To"] = receiver_email
+    for username in users_to_email:
+        receiver_email = user_info[username]["email"]
+        if receiver_email != "": # user has paired an email
+            message = MIMEMultipart("alternative")
+            message["Subject"] = "New music on Spotify"
+            message["From"] = sender_email
+            message["To"] = receiver_email
 
-    playlist_link = "https://open.spotify.com/playlist/" + playlist_id
+            playlist_link = "https://open.spotify.com/playlist/" + user_info[username]["playlist_id"]
 
-    # create the plain-text and HTML versions of the message
-    text = "We've detected new music!\nCheck it out in your New Music playlist on Spotify"
-    html = """\
-    <html>
-        <body>
-            <p>We've detected new music!<br>
-            Check it out in your <a href="{:s}">New Music playlist</a></p>
-        </body>
-    </html>
-    """.format(playlist_link)
+            # create the plain-text and HTML versions of the message
+            text = "We've detected new music!\nCheck it out in your New Music playlist on Spotify"
+            html = """\
+            <html>
+                <body>
+                    <p>We've detected new music!<br>
+                    Check it out in your <a href="{:s}">New Music playlist</a></p>
+                </body>
+            </html>
+            """.format(playlist_link)
 
-    # turn the messages into plain/html MIMEText objects
-    part1 = MIMEText(text, "plain")
-    part2 = MIMEText(html, "html")
+            # turn the messages into plain/html MIMEText objects
+            part1 = MIMEText(text, "plain")
+            part2 = MIMEText(html, "html")
 
-    message.attach(part1)
-    message.attach(part2)
+            message.attach(part1)
+            message.attach(part2)
 
-    context = ssl.create_default_context()
-    with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as server:
-        server.login(sender_email, sender_password)
-        server.sendmail(sender_email, receiver_email, message.as_string())
-
-def add_to_playlist(username, playlist_id, new_music, app_info, sp):
-    """
-        Adds all the songs from each album in new_music to the supplied playlist_id for the given username.
-        If the playlist does not exist it will be created and have its id written to app_info.txt
-        :param username: the username to find/create the playlist under
-        :param playlist_id: the id of the playlist to find (will be "" if it does not exist)
-        :param new_music: a dictionary of new music from update_followed_artists()
-        :param app_info: the lines from app_info.txt, obtained in read_app_info()
-        :param sp: the Spotipy object
-        :return: the newly created playlist id, or None if it already existed
-    """
-    album_ids = []
-    # turn dictionary of new music into list of album ids
-    for artist_id in new_music.keys():
-        album_ids.extend(new_music[artist_id]['albums'])
-        album_ids.extend(new_music[artist_id]['singles'])
-    
-    # turn the list of album ids into a list of all the song ids from each album
-    # calls the API to get the songs from each album id
-    song_ids = []
-    for album_id in album_ids:
-        for song in sp.album(album_id)["tracks"]["items"]: # call API to get all the song ids within the given album_id
-            song_ids.append(song["id"])
-
-    # try to add song ids to the playlist
-    try:
-        sp.user_playlist_add_tracks(username, playlist_id, song_ids) # add track
-    except: # playlist has not been made before or does not exist anymore
-        # overwrite line for playlist_id in app_info.txt
-        file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "app_info.txt") # adds the path up to the file for running different working directory settings
-        app_info_fp = open(file_name, 'w')
-        for i in range(0, 8):
-            app_info_fp.write(app_info[i] + '\n')
-
-        # call the API and create a private playlist then return a dict of related info
-        playlist = sp.user_playlist_create(username, "New Music", False, "New music from music notifier, checked daily and updated here.")
-        
-        # add a playlist cover
-        file_name = os.path.join(os.path.dirname(os.path.abspath(__file__)), "playlist_cover.jpg")
-        with open(file_name, "rb") as img_file:
-            image_data = base64.b64encode(img_file.read())
-            sp.playlist_upload_cover_image(playlist["id"], image_data)
-        
-        app_info_fp.write(playlist["id"])
-        app_info_fp.close()
-
-        sp.user_playlist_add_tracks(username, playlist["id"], song_ids) # add tracks to the newly-created playlist
-        
-        return playlist["id"]
+            # send email
+            context = ssl.create_default_context()
+            with smtplib.SMTP_SSL("smtp.gmail.com", 465, context=context) as server:
+                server.login(sender_email, sender_password)
+                server.sendmail(sender_email, receiver_email, message.as_string())
 
 if __name__ == '__main__':
-    app_info = read_app_info()
-    # app_info is formatted: [username, client_id, client_secret, redirect_uri, sender_email, sender_password, receiver_email, placeholder, *playlist_id]
-    
-    sp = set_credentials(app_info[0], app_info[1], app_info[2], app_info[3]) # create spotipy object and set credentials
+    app_info = read_app_info() # get information from app_info.txt
+    # app_info is formatted: [client_id, client_secret, redirect_uri, sender_email, sender_password]
 
-    new_music = update_followed_artists(sp)
+    user_info = {}
+    spotipy_objects = {} # to be a dict formatted as username:spotipy_object
+    users = [] # will be a list of usernames from the cache_files folder
 
-    if new_music is not None and new_music != {}: # there was new music found
-        new_playlist_id = add_to_playlist(app_info[0], app_info[8], new_music, app_info, sp) # add new music to playlist
-        
-        if (app_info[4] != "(Sender Email Address *Optional)"): # user has filled in information for sending email
-            if new_playlist_id is not None: # update playlist_id if necessary
-                app_info[8] = new_playlist_id 
-            
-            send_email(app_info[4], app_info[5], app_info[6], app_info[8]) # send an email
+    for cache_name in os.listdir(os.getcwd() + "\\cache_files"): # for cache file in the cache_files folder
+        username = cache_name[7:].strip() # all cache files are formatted ".cache-username"
+
+        sp = set_credentials(username, app_info[0], app_info[1], app_info[2]) # create spotipy object and set credentials
+        spotipy_objects[username] = sp
+        user_info = update_user_info(username, sp)
+        users.append(username)
+
+    remove_users(users, user_info) # remove users who are no longer in cache_files to prevent unnecessary API calls
+    new_music, log_information = get_new_music(user_info) # collect new music from artists the userbase as a whole follows
+    users_to_email = update_playlists(user_info, new_music, spotipy_objects, log_information) # update playlists of users
+    send_email(app_info[3], app_info[4], users_to_email, user_info) # send emails to users who have an email on their account


### PR DESCRIPTION
Rewrote the whole project. The script now loops through each cache files in the cache_files folder and updates the user_info.txt file with their followed artists, or if the user does not have their information saved it will do so. It then removes users whose cache file no longer appears in the cache folder to prevent unnecessary API calls. It then creates a list of all artists followed by all users so as to only call the API for each artist once. It collects the last 5 singles and albums for each artist, then creates a new music dict of albums/singles released in the past day. It then pairs the new music with users who follow the artist and updates all the necessary Spotify playlists. Albums added to playlists per user are logged as a text file in the logs folder. Finally emails are sent out to users whose playlists were updated and who have an email on their account.

generate_cache.py is included to create cache files
README updated significantly